### PR TITLE
Filter JS `try...catch` from lyrics

### DIFF
--- a/xlyrics.js
+++ b/xlyrics.js
@@ -74,6 +74,7 @@ function getLyrics(url){
                 var htmlTitle = $('title').text();
                 console.log(chalk.bold.blue(htmlTitle.replace(' Lyrics', '')), '\n');
                 lyric = lyric.replace(/\t/g, '');
+                lyric = lyric.replace('try { _402_Show(); } catch(e) {}', '');
                 lyric = lyric.split('\r\n');
                 lyric = lyric[0].split('\n');
                 lyric = lyric.slice(7);


### PR DESCRIPTION
Lyrics were returning `try { _402_Show(); } catch(e) {}` at the end.  It was getting scraped along with the lyrics.